### PR TITLE
Fix grepl for ribosomal proteins

### DIFF
--- a/vignettes/gRodon-vignette.Rmd
+++ b/vignettes/gRodon-vignette.Rmd
@@ -110,7 +110,7 @@ gene_IDs <- gsub(" .*","",names(genes)) #Just look at first part of name before 
 genes <- genes[gene_IDs %in% CDS_IDs]
 
 #Search for genes annotated as ribosomal proteins
-highly_expressed <- grepl("ribosomal protein",names(genes),ignore.case = T)
+highly_expressed <- grepl("^(?!.*(methyl|hydroxy)).*0S ribosomal protein",names(genes),ignore.case = T, perl = TRUE)
 ```
 
 You are now ready to run gRodon.


### PR DESCRIPTION
Currently in the vignette the `grepl` for highly expressed genes (ie. ribosomal proteins) when using prokka output is `highly_expressed <- grepl("ribosomal protein",names(genes),ignore.case = T)`. [link](https://github.com/jlw-ecoevo/gRodon2/blob/ee3b03f167d5232be07b319f3466bc2b93b19e48/vignettes/gRodon-vignette.Rmd#L113).

However, using the above command returns other enzymes associated with ribosomal proteins which are not highly expressed , example, 
- 50S ribosomal protein L3 glutamine methyltransferase
- 50S ribosomal protein L16 3-hydroxylase
- Ribosomal protein S12 methylthiotransferase RimO

Current `grepl` should be replaced with the following to reduce as many of these incorrect enzyme annotations as possible.
`highly_expressed <- grepl("^(?!.*(methyl|hydroxy)).*0S ribosomal protein",names(genes),ignore.case = T, perl = TRUE)`